### PR TITLE
[ADD]헤더수정

### DIFF
--- a/preface/package-lock.json
+++ b/preface/package-lock.json
@@ -26,7 +26,6 @@
         "react-scripts": "5.0.1",
         "redux": "^4.2.0",
         "redux-logger": "^3.0.6",
-        "redux-persist": "^6.0.0",
         "redux-saga": "^1.2.1",
         "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
@@ -34,7 +33,8 @@
       "devDependencies": {
         "eslint-config-prettier": "^8.5.0",
         "husky": "^8.0.1",
-        "prettier": "^2.7.1"
+        "prettier": "^2.7.1",
+        "redux-persist": "^6.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -14944,6 +14944,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
       "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "dev": true,
       "peerDependencies": {
         "redux": ">4.0.0"
       }
@@ -28110,6 +28111,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
       "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "dev": true,
       "requires": {}
     },
     "redux-saga": {

--- a/preface/src/components/Header/Header.jsx
+++ b/preface/src/components/Header/Header.jsx
@@ -1,11 +1,24 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { styled } from '@mui/material'
+import { useSelector } from 'react-redux'
+import { useLocation } from 'react-router-dom'
+import { NAV_CONFIG } from 'components/Sider/Sider'
 
 function Header() {
+  const data = useSelector(state => state.auth)
+  const location = useLocation()
+  const pageTitle = useMemo(() => {
+    const page = NAV_CONFIG.find(page => location.pathname.includes(page.path))
+    return page?.title
+  }, [location.pathname])
+
   return (
     <HeaderContainer>
       <SideOverlap />
-      <HeaderSection>Header</HeaderSection>
+      <HeaderSection>
+        <PageName>{pageTitle}</PageName>
+        <UserName>{data.userId}</UserName>
+      </HeaderSection>
     </HeaderContainer>
   )
 }
@@ -13,7 +26,6 @@ function Header() {
 export default Header
 
 const HeaderContainer = styled('div')({
-  boxSizing: 'border-box',
   position: 'fixed',
   top: 0,
   left: 0,
@@ -30,6 +42,19 @@ const SideOverlap = styled('div')({
 })
 
 const HeaderSection = styled('div')({
-  flex: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '0 30px',
+  flex: 1,
   width: '100%',
+})
+
+const PageName = styled('p')({
+  fontSize: '1.5rem',
+  fontWeight: 'bold',
+})
+
+const UserName = styled('p')({
+  fontWeight: 'bold',
 })

--- a/preface/src/components/Sider/Sider.jsx
+++ b/preface/src/components/Sider/Sider.jsx
@@ -3,14 +3,14 @@ import { styled } from '@mui/material'
 import NavMenuGroup from './components/NavMenuGroup'
 import LogoutButton from './components/LogoutButton'
 
-const NAV_CONFIG = [
+export const NAV_CONFIG = [
   {
     title: '계좌목록',
-    path: '/main/accountList',
+    path: '/main/accountlist',
   },
   {
     title: '사용자 정보',
-    path: '/main/userList',
+    path: '/main/userlist',
   },
 ]
 

--- a/preface/src/components/Sider/components/NavMenuGroup.jsx
+++ b/preface/src/components/Sider/components/NavMenuGroup.jsx
@@ -14,7 +14,7 @@ const NavMenuGroup = ({ menuList }) => {
       {menuList.map((menuItem, index) => (
         <ListItemButton
           key={index}
-          selected={location.pathname === menuItem.path}
+          selected={location.pathname.includes(menuItem.path)}
           onClick={() => movePage(menuItem.path)}
         >
           <ListItemText primary={menuItem.title} />

--- a/preface/src/index.js
+++ b/preface/src/index.js
@@ -1,13 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
-
+import { CssBaseline } from '@mui/material'
 import { Provider } from 'react-redux'
-import { store } from 'store'
+import { store, persistor } from 'store'
+import { PersistGate } from 'redux-persist/integration/react'
 
 const root = ReactDOM.createRoot(document.getElementById('root'))
 root.render(
   <Provider store={store}>
-    <App />
+    <PersistGate loading={null} persistor={persistor}>
+      <CssBaseline />
+      <App />
+    </PersistGate>
   </Provider>,
 )

--- a/preface/src/pages/main/Main.jsx
+++ b/preface/src/pages/main/Main.jsx
@@ -26,6 +26,7 @@ const MainContainer = styled('div')({
   display: 'flex',
   paddingLeft: 250,
   overflow: 'hidden',
+  margin: 0,
 })
 
 const MainSection = styled('section')({

--- a/preface/src/store/index.js
+++ b/preface/src/store/index.js
@@ -1,8 +1,19 @@
 import { configureStore } from '@reduxjs/toolkit'
 import authReducer from 'redux/slice/AuthSlice'
 import { thunk } from 'redux/middleware/Thunk'
+import { persistStore, persistReducer } from 'redux-persist'
+import storage from 'redux-persist/lib/storage'
+
+const persistConfig = {
+  key: 'auth',
+  storage,
+}
+
+const persistAuth = persistReducer(persistConfig, authReducer)
 
 export const store = configureStore({
-  reducer: { auth: authReducer },
+  reducer: { auth: persistAuth },
   middleware: [thunk],
 })
+
+export const persistor = persistStore(store)


### PR DESCRIPTION
헤더 페이지제목 및 로그인 유저이름 등록

페이지 이동시 useLocation 으로 해당 경로가 기존 메뉴 객체의 path 파라미터에 포함되는 경우에 메뉴객체의 title을 나타내도록 하였습니다.

유저정보를 리덕스로 관리할 경우 새로고침 시 유저정보가 사라지는 현상을, redux-persist를 사용하여 유저정보가 localstorage에 저장하여 정보가 유지되도록 하였습니다.